### PR TITLE
t.register accepts only real users

### DIFF
--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -44,4 +44,4 @@ module.exports = {
 			}
 		});
 	},
-};
+}; 

--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -24,7 +24,6 @@ module.exports = {
 						// users that don't exist will always have meta name="robots" and channels will always have button saying "Preview channel"
 						if (chunk.toString().includes("robots", "Preview channel")) {
 							message.channel.send("This is not a telegram user.")
-							console.log(message.content.slice(11))
 						} else {
 							const addUserDB = new UserModel({
 								name: message.author.id,

--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -8,42 +8,40 @@ module.exports = {
 		UserModel.findOne({ name: message.author.id }, function(err, users) {
 			if (err) return;
 			if (users != null) {
-				return message.channel.send(
-					"You are already registered in my database,\nif you wish to edit or remove yourself from the database please use the appropate commands (see **t.help** for more info)",
-				);
+				return message.channel.send("You are already registered in my database,\nif you wish to edit or remove yourself from the database please use the appropate commands (see **t.help** for more info)");
 			}
 			let URL = message.content.slice(11);
-			if (URL.match(/((?:http|https|)\/\/(?:t|telegram)\.me)/gi) || URL.match(/([!@#$%^&*(),.?":{}|<>])/gi)) {
-				// Checks if the link is using https, if not it upgrades the connection to https
-				if (!URL.match(/https/gi)) {
-					URL = "https" + URL.slice(4);
-					console.log(URL);
-				}	
-				// Send HTTP GET request with this URL, and make sure that this is a user
-				https.get(URL, (response) => {
-					response.on("data", (chunk) => {
+			if (URL.match(/((?:http|https|)\/\/(?:t|telegram)\.me)/gi)) {
+				if(!URL.match(/([!#$%^&*(),?"{}|<>])/gi)){
+					// Checks if the link is using https, if not it upgrades the connection to https
+					if (!URL.match(/https/gi)) {
+						URL = "https" + URL.slice(4);
+					}	
+					// Send HTTP GET request with this URL, and make sure that this is a user
+					https.get(URL, (response) => {
+						response.on("data", (chunk) => {
 						// users that don't exist will always have meta name="robots" and channels will always have button saying "Preview channel"
-						if (chunk.toString().includes("robots", "Preview channel")) {
-							message.channel.send("hmm... I couldn't find any registered telegram users associated with that link, if you're new to telegram sign up at <https://web.telegram.org>");
-						}
-						else {
-							const addUserDB = new UserModel({
-								name: message.author.id,
-								link: URL,
-							});
-							addUserDB.save(function(err, addUserDB) {
-								if (err) return console.error(err);
-								message.channel.send("Congrats you registered successfully");
-							});
-						}
+							if (chunk.toString().includes("robots", "Preview channel")) {
+								message.channel.send("hmm... I couldn't find any registered telegram users associated with that link, if you're new to telegram sign up at <https://web.telegram.org>");
+							}
+							else {
+								const addUserDB = new UserModel({
+									name: message.author.id,
+									link: URL,
+								});
+								addUserDB.save(function(err, addUserDB) {
+									if (err) return console.error(err);
+									message.channel.send("Congrats you registered successfully");
+								});
+							}
+						});
 					});
-				});
+				}
+				
 			}
 			else {
 				console.log(err);
-				return message.channel.send(
-					"hmm... that doesn't seem to be a valid telegram link\nmake sure you formatted the command properly (check t.help to see proper formatting)",
-				);
+				return message.channel.send("hmm... that doesn't seem to be a valid telegram link\nmake sure you formatted the command properly (check t.help to see proper formatting)");
 			}
 		});
 	},

--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -12,31 +12,35 @@ module.exports = {
 					"You are already registered in my database,\nif you wish to edit or remove yourself from the database please use the appropate commands (see **t.help** for more info)",
 				);
 			}
-			if (
-				message.content
-					.slice(11)
-					.match(/((?:http|https|)\/\/(?:t|telegram)\.me)/gi)
-			) {	
-				const URL = message.content.slice(11)
+			let URL = message.content.slice(11);
+			if (URL.match(/((?:http|https|)\/\/(?:t|telegram)\.me)/gi) || URL.match(/([!@#$%^&*(),.?":{}|<>])/gi)) {
+				// Checks if the link is using https, if not it upgrades the connection to https
+				if (!URL.match(/https/gi)) {
+					URL = "https" + URL.slice(4);
+					console.log(URL);
+				}	
 				// Send HTTP GET request with this URL, and make sure that this is a user
 				https.get(URL, (response) => {
 					response.on("data", (chunk) => {
 						// users that don't exist will always have meta name="robots" and channels will always have button saying "Preview channel"
 						if (chunk.toString().includes("robots", "Preview channel")) {
-							message.channel.send("This is not a telegram user.")
-						} else {
+							message.channel.send("hmm... I couldn't find any registered telegram users associated with that link, if you're new to telegram sign up at <https://web.telegram.org>");
+						}
+						else {
 							const addUserDB = new UserModel({
 								name: message.author.id,
-								link: message.content.slice(11).trim(),
+								link: URL,
 							});
 							addUserDB.save(function(err, addUserDB) {
 								if (err) return console.error(err);
 								message.channel.send("Congrats you registered successfully");
 							});
 						}
-					})
-				})
-			} else {
+					});
+				});
+			}
+			else {
+				console.log(err);
 				return message.channel.send(
 					"hmm... that doesn't seem to be a valid telegram link\nmake sure you formatted the command properly (check t.help to see proper formatting)",
 				);


### PR DESCRIPTION
t.register did accept anything, for example you could do `t.register https://t.me/fwpefmjwpiefpwef` and it would send message "Congrats you registered successfully", now it will send a message "This is not a telegram user"